### PR TITLE
Prevent TypeError if optional role isn't provided

### DIFF
--- a/module.js
+++ b/module.js
@@ -917,7 +917,7 @@ function JSONstat(resp,f){
 				tbl=[],
 				head=totbl.shift(),
 				//0.12.3
-				metric=dataset.role.metric,
+				metric=dataset.role && dataset.role.metric,
 				addUnits=function(){},
 				metriclabels={}
 			;


### PR DESCRIPTION
[`role` is optional](https://json-stat.org/format/#role) but the code assumes it is present. 

`toTable({ type: 'arrobj' })` throws a `TypeError` if it's missing.